### PR TITLE
Add many missing parser columns and a whole file

### DIFF
--- a/FileExtensions/FileExtensions.csproj
+++ b/FileExtensions/FileExtensions.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>D2RReimaginedTools.FileExtensions</PackageId>
-        <Version>0.3.0</Version>
+        <Version>0.4.0</Version>
         <Authors>ScottieKnowz</Authors>
         <Company>D2RReimagined</Company>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/FileExtensions/JsonFileParsers/TranslationFileParser.cs
+++ b/FileExtensions/JsonFileParsers/TranslationFileParser.cs
@@ -22,9 +22,15 @@ public class TranslationFileParser(string filePath)
         var json = await File.ReadAllTextAsync(filePath);
         _translations = JsonSerializer.Deserialize<List<TranslatableString>>(json, new JsonSerializerOptions
         {
-            PropertyNameCaseInsensitive = true
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true
         }) ?? [];
         return _translations;
+    }
+    
+    public async Task<List<TranslatableString>> GetAllEntriesAsync()
+    {
+        return await LoadTranslationsAsync();
     }
     
     public async Task<TranslatableString> GetTranslationByKeyAsync(string key)

--- a/FileExtensions/Models/ItemProperty.cs
+++ b/FileExtensions/Models/ItemProperty.cs
@@ -4,6 +4,6 @@ public class ItemProperty
 {
     public string? Property { get; init; }
     public string? Parameter { get; init; }
-    public int Min { get; init; }
-    public int Max { get; init; }
+    public int? Min { get; init; }
+    public int? Max { get; init; }
 }

--- a/FileExtensions/Models/PropertyGroup.cs
+++ b/FileExtensions/Models/PropertyGroup.cs
@@ -1,0 +1,64 @@
+﻿namespace D2RReimaginedTools.Models;
+
+public record PropertyGroup
+{
+    public string? Code { get; set; }
+    public int? Id { get; set; }
+    public int? PickMode { get; set; }
+
+    public string? Prop1 { get; set; }
+    public string? ParMin1 { get; set; }
+    public string? ParMax1 { get; set; }
+    public int? ModMin1 { get; set; }
+    public int? ModMax1 { get; set; }
+    public int? Chance1 { get; set; }
+
+    public string? Prop2 { get; set; }
+    public string? ParMin2 { get; set; }
+    public string? ParMax2 { get; set; }
+    public int? ModMin2 { get; set; }
+    public int? ModMax2 { get; set; }
+    public int? Chance2 { get; set; }
+
+    public string? Prop3 { get; set; }
+    public string? ParMin3 { get; set; }
+    public string? ParMax3 { get; set; }
+    public int? ModMin3 { get; set; }
+    public int? ModMax3 { get; set; }
+    public int? Chance3 { get; set; }
+
+    public string? Prop4 { get; set; }
+    public string? ParMin4 { get; set; }
+    public string? ParMax4 { get; set; }
+    public int? ModMin4 { get; set; }
+    public int? ModMax4 { get; set; }
+    public int? Chance4 { get; set; }
+
+    public string? Prop5 { get; set; }
+    public string? ParMin5 { get; set; }
+    public string? ParMax5 { get; set; }
+    public int? ModMin5 { get; set; }
+    public int? ModMax5 { get; set; }
+    public int? Chance5 { get; set; }
+
+    public string? Prop6 { get; set; }
+    public string? ParMin6 { get; set; }
+    public string? ParMax6 { get; set; }
+    public int? ModMin6 { get; set; }
+    public int? ModMax6 { get; set; }
+    public int? Chance6 { get; set; }
+
+    public string? Prop7 { get; set; }
+    public string? ParMin7 { get; set; }
+    public string? ParMax7 { get; set; }
+    public int? ModMin7 { get; set; }
+    public int? ModMax7 { get; set; }
+    public int? Chance7 { get; set; }
+
+    public string? Prop8 { get; set; }
+    public string? ParMin8 { get; set; }
+    public string? ParMax8 { get; set; }
+    public int? ModMin8 { get; set; }
+    public int? ModMax8 { get; set; }
+    public int? Chance8 { get; set; }
+}

--- a/FileExtensions/Models/SetItems.cs
+++ b/FileExtensions/Models/SetItems.cs
@@ -26,6 +26,7 @@ public class SetItem
     public int? CostMultiplier { get; set; }
     public int? CostAdd { get; set; }
     public int? AddFunc { get; set; }
+    public int? Vanilla { get; set; }
     public string? Prop1 { get; set; }
     public string? Par1 { get; set; }
     public int? Min1 { get; set; }

--- a/FileExtensions/TextFileParsers/CubeModParser.cs
+++ b/FileExtensions/TextFileParsers/CubeModParser.cs
@@ -1,5 +1,14 @@
+using System.Collections.Generic;
 using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class CubeModifierTypeParser : HeaderMappedTextFileParser<CubeModifierType, CubeModifierTypeParser>;
+public class CubeModifierTypeParser : HeaderMappedTextFileParser<CubeModifierType, CubeModifierTypeParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Aliases = new Dictionary<string, string[]>
+    {
+        [nameof(CubeModifierType.CubeModifierTypeName)] = ["cube modifier type"]
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => Aliases;
+}

--- a/FileExtensions/TextFileParsers/HeaderMappedTextFileParser.cs
+++ b/FileExtensions/TextFileParsers/HeaderMappedTextFileParser.cs
@@ -79,9 +79,11 @@ public abstract class HeaderMappedTextFileParser<TEntry, TParser>
         }
 
         var header = lines[HeaderRowIndex].Split('\t');
-        var columnMap = header
-            .Select((name, index) => new { name, index })
-            .ToDictionary(x => NormalizeColumnName(x.name), x => x.index, StringComparer.OrdinalIgnoreCase);
+        var columnMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < header.Length; i++)
+        {
+            columnMap.TryAdd(NormalizeColumnName(header[i]), i);
+        }
 
         return lines
             .Skip(DataStartRowIndex)
@@ -173,12 +175,13 @@ public abstract class HeaderMappedTextFileParser<TEntry, TParser>
         }
 
         var targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        var isNullable = Nullable.GetUnderlyingType(propertyType) is not null;
 
         if (targetType == typeof(bool))
         {
-            if (string.IsNullOrWhiteSpace(value) && Nullable.GetUnderlyingType(propertyType) is not null)
+            if (string.IsNullOrWhiteSpace(value))
             {
-                return null;
+                return isNullable ? null : false;
             }
 
             return value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase);
@@ -186,24 +189,22 @@ public abstract class HeaderMappedTextFileParser<TEntry, TParser>
 
         if (string.IsNullOrWhiteSpace(value))
         {
-            return Nullable.GetUnderlyingType(propertyType) is not null
-                ? null
-                : Activator.CreateInstance(targetType);
+            return isNullable ? null : Activator.CreateInstance(targetType);
         }
 
         return targetType switch
         {
-            _ when targetType == typeof(byte) => byte.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(sbyte) => sbyte.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(short) => short.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(ushort) => ushort.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(int) => int.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(uint) => uint.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(long) => long.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(ulong) => ulong.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(float) => float.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(double) => double.Parse(value, CultureInfo.InvariantCulture),
-            _ when targetType == typeof(decimal) => decimal.Parse(value, CultureInfo.InvariantCulture),
+            _ when targetType == typeof(byte) => byte.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(sbyte) => sbyte.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(short) => short.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(ushort) => ushort.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(int) => int.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(uint) => uint.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(long) => long.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(ulong) => ulong.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(float) => float.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(double) => double.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
+            _ when targetType == typeof(decimal) => decimal.TryParse(value, CultureInfo.InvariantCulture, out var result) ? (object)result : (isNullable ? null : default),
             _ => value
         };
     }

--- a/FileExtensions/TextFileParsers/ItemTypesParser.cs
+++ b/FileExtensions/TextFileParsers/ItemTypesParser.cs
@@ -2,4 +2,14 @@ using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class ItemTypeParser : HeaderMappedTextFileParser<ItemType, ItemTypeParser>;
+public class ItemTypeParser : HeaderMappedTextFileParser<ItemType, ItemTypeParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> _aliases = new Dictionary<string, string[]>
+    {
+        [nameof(ItemType.ItemTypeName)] = ["ItemType"],
+        [nameof(ItemType.MaxSocketsLevelThreshold1)] = ["MaxSocketsLevelThreshold1"], // In case normalization differs
+        [nameof(ItemType.MaxSocketsLevelThreshold2)] = ["MaxSocketsLevelThreshold2"]
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => _aliases;
+}

--- a/FileExtensions/TextFileParsers/MissilesParser.cs
+++ b/FileExtensions/TextFileParsers/MissilesParser.cs
@@ -107,6 +107,8 @@ public class MissilesParser : HeaderMappedTextFileParser<Missiles, MissilesParse
         [nameof(Missiles.ClientHitSubMissile1)] = ["CltHitSubMissile1"],
         [nameof(Missiles.ClientHitSubMissile2)] = ["CltHitSubMissile2"],
         [nameof(Missiles.ClientHitSubMissile3)] = ["CltHitSubMissile3"],
+        [nameof(Missiles.Acceleration)] = ["Accel"],
+        [nameof(Missiles.AnimationSpeed)] = ["AnimSpeed"],
         [nameof(Missiles.ClientHitSubMissile4)] = ["CltHitSubMissile4"]
     };
 

--- a/FileExtensions/TextFileParsers/PetTypeParser.cs
+++ b/FileExtensions/TextFileParsers/PetTypeParser.cs
@@ -1,5 +1,14 @@
+using System.Collections.Generic;
 using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class PetTypeParser : HeaderMappedTextFileParser<PetType, PetTypeParser>;
+public class PetTypeParser : HeaderMappedTextFileParser<PetType, PetTypeParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Aliases = new Dictionary<string, string[]>
+    {
+        [nameof(PetType.PetTypeId)] = ["pet type"]
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => Aliases;
+}

--- a/FileExtensions/TextFileParsers/PropertyGroupParser.cs
+++ b/FileExtensions/TextFileParsers/PropertyGroupParser.cs
@@ -1,0 +1,5 @@
+﻿using D2RReimaginedTools.Models;
+
+namespace D2RReimaginedTools.TextFileParsers;
+
+public class PropertyGroupParser : HeaderMappedTextFileParser<PropertyGroup, PropertyGroupParser>;

--- a/FileExtensions/TextFileParsers/SetItemParser.cs
+++ b/FileExtensions/TextFileParsers/SetItemParser.cs
@@ -1,54 +1,71 @@
-﻿namespace D2RReimaginedTools.TextFileParsers;
-
+﻿using System.Collections.Generic;
 using D2RReimaginedTools.Models;
-using D2RReimaginedTools.Extensions;
 
-public static class TsvToSetItemExtensions
+namespace D2RReimaginedTools.TextFileParsers;
+
+public class SetItemParser : HeaderMappedTextFileParser<SetItem, SetItemParser>
 {
-    public static SetItem ToSetItem(this string[] columns)
+    private static readonly IReadOnlyDictionary<string, string[]> _aliases = new Dictionary<string, string[]>
     {
-        return new SetItem
-        {
-            Index = columns[0],
-            Id = columns[1],
-            Set = columns[2],
-            Item = columns[3],
-            ItemName = columns[4],
-            Rarity = columns[5].ToNullableInt(),
-            Level = columns[6].ToNullableInt(),
-            LevelRequirement = columns[7].ToNullableInt(),
-            CharacterTransform = columns[8],
-            InventoryTransform = columns[9],
-            InventoryFile = columns[10],
-            FlippyFile = columns[11],
-            DropSound = columns[12],
-            DropSfxFrame = columns[13].ToNullableInt(),
-            UseSound = columns[14],
-            CostMultiplier = columns[15].ToNullableInt(),
-            CostAdd = columns[16].ToNullableInt(),
-            AddFunc = columns[17].ToNullableInt(),
+        [nameof(SetItem.LevelRequirement)] = ["lvl req"],
+        [nameof(SetItem.CostMultiplier)] = ["cost mult"]
+    };
 
-            Properties = ExtractMods(columns, 18, 9),
-            AdditionalProperties = ExtractMods(columns, 54, 10),
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => _aliases;
 
-            DiabloCloneWeight = columns[94].ToNullableInt()
-        };
+    protected override SetItem FinalizeEntry(SetItem entry, string[] columns, IReadOnlyDictionary<string, int> columnMap)
+    {
+        entry.Properties = ExtractBaseMods(columns, columnMap);
+        entry.AdditionalProperties = ExtractAdditionalMods(columns, columnMap);
+        return entry;
     }
 
-    private static List<SetItemMod> ExtractMods(string[] columns, int start, int count)
+    private static List<SetItemMod> ExtractBaseMods(string[] columns, IReadOnlyDictionary<string, int> columnMap)
     {
         var mods = new List<SetItemMod>();
-        for (int i = 0; i < count; i++)
+        for (int i = 1; i <= 9; i++)
         {
-            int index = start + i * 4;
+            if (!columnMap.TryGetValue($"prop{i}", out var codeIdx)) continue;
+            var code = columns[codeIdx];
+            if (string.IsNullOrEmpty(code)) continue;
+
             mods.Add(new SetItemMod
             {
-                Code = columns[index],
-                Param = columns[index + 1],
-                Min = columns[index + 2].ToNullableInt(),
-                Max = columns[index + 3].ToNullableInt()
+                Code = code,
+                Param = columnMap.TryGetValue($"par{i}", out var parIdx) ? columns[parIdx] : null,
+                Min = columnMap.TryGetValue($"min{i}", out var minIdx) ? ParseNullableInt(columns[minIdx]) : null,
+                Max = columnMap.TryGetValue($"max{i}", out var maxIdx) ? ParseNullableInt(columns[maxIdx]) : null
             });
         }
         return mods;
+    }
+
+    private static List<SetItemMod> ExtractAdditionalMods(string[] columns, IReadOnlyDictionary<string, int> columnMap)
+    {
+        var mods = new List<SetItemMod>();
+        // aprop1a, apar1a, amin1a, amax1a, aprop1b, etc.
+        for (int i = 1; i <= 5; i++)
+        {
+            foreach (var suffix in new[] { "a", "b" })
+            {
+                if (!columnMap.TryGetValue($"aprop{i}{suffix}", out var codeIdx)) continue;
+                var code = columns[codeIdx];
+                if (string.IsNullOrEmpty(code)) continue;
+
+                mods.Add(new SetItemMod
+                {
+                    Code = code,
+                    Param = columnMap.TryGetValue($"apar{i}{suffix}", out var parIdx) ? columns[parIdx] : null,
+                    Min = columnMap.TryGetValue($"amin{i}{suffix}", out var minIdx) ? ParseNullableInt(columns[minIdx]) : null,
+                    Max = columnMap.TryGetValue($"amax{i}{suffix}", out var maxIdx) ? ParseNullableInt(columns[maxIdx]) : null
+                });
+            }
+        }
+        return mods;
+    }
+
+    private static int? ParseNullableInt(string s)
+    {
+        return int.TryParse(s, out var result) ? result : null;
     }
 }

--- a/FileExtensions/TextFileParsers/StorePageParser.cs
+++ b/FileExtensions/TextFileParsers/StorePageParser.cs
@@ -1,5 +1,14 @@
+using System.Collections.Generic;
 using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class StorePageParser : HeaderMappedTextFileParser<StorePage, StorePageParser>;
+public class StorePageParser : HeaderMappedTextFileParser<StorePage, StorePageParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Aliases = new Dictionary<string, string[]>
+    {
+        [nameof(StorePage.StorePageName)] = ["Store Page"]
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => Aliases;
+}

--- a/FileExtensions/TextFileParsers/TreasureClassParser.cs
+++ b/FileExtensions/TextFileParsers/TreasureClassParser.cs
@@ -1,5 +1,14 @@
+using System.Collections.Generic;
 using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class TreasureClassParser : HeaderMappedTextFileParser<TreasureClass, TreasureClassParser>;
+public class TreasureClassParser : HeaderMappedTextFileParser<TreasureClass, TreasureClassParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Aliases = new Dictionary<string, string[]>
+    {
+        [nameof(TreasureClass.TreasureClassName)] = ["Treasure Class"]
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => Aliases;
+}

--- a/FileExtensions/TextFileParsers/UniqueItemsParser.cs
+++ b/FileExtensions/TextFileParsers/UniqueItemsParser.cs
@@ -7,6 +7,7 @@ public class UniqueItemsParser : HeaderMappedTextFileParser<UniqueItem, UniqueIt
 {
     private static readonly IReadOnlyDictionary<string, string[]> _aliases = new Dictionary<string, string[]>
     {
+        [nameof(UniqueItem.Code)] = ["item"],
         [nameof(UniqueItem.Level)] = ["lvl"],
         [nameof(UniqueItem.LevelRequirement)] = ["lvl req"],
         [nameof(UniqueItem.CostMultiplier)] = ["cost mult"]
@@ -52,8 +53,8 @@ public class UniqueItemsParser : HeaderMappedTextFileParser<UniqueItem, UniqueIt
         return typeof(UniqueItem).GetProperty(propertyName)?.GetValue(entry) as string;
     }
 
-    private static int GetInt(UniqueItem entry, string propertyName)
+    private static int? GetInt(UniqueItem entry, string propertyName)
     {
-        return (int?)typeof(UniqueItem).GetProperty(propertyName)?.GetValue(entry) ?? 0;
+        return (int?)typeof(UniqueItem).GetProperty(propertyName)?.GetValue(entry);
     }
 }

--- a/FileExtensions/TextFileParsers/WeaponParser.cs
+++ b/FileExtensions/TextFileParsers/WeaponParser.cs
@@ -1,5 +1,18 @@
+using System.Collections.Generic;
 using D2RReimaginedTools.Models;
 
 namespace D2RReimaginedTools.TextFileParsers;
 
-public class WeaponParser : HeaderMappedTextFileParser<Weapon, WeaponParser>;
+public class WeaponParser : HeaderMappedTextFileParser<Weapon, WeaponParser>
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Aliases = new Dictionary<string, string[]>
+    {
+        [nameof(Equipment.OneOrTwoHanded)] = ["1or2handed"],
+        [nameof(Equipment.TwoHanded)] = ["2handed"],
+        [nameof(Equipment.TwoHandMinDam)] = ["2handmindam"],
+        [nameof(Equipment.TwoHandMaxDam)] = ["2handmaxdam"],
+        [nameof(Equipment.TwoHandedWClass)] = ["2handedwclass"],
+    };
+
+    protected override IReadOnlyDictionary<string, string[]> PropertyColumnAliases => Aliases;
+}


### PR DESCRIPTION
Update to v4.0

Add in missing propertygroups.txt model and parser file
Add in missing column alias causing issues with my Orb & Rune tweak

Add in fault tolerance because some columns contain multiple data types throughout the files and caused full crashes during my plugin expansion testing.

Add in missing column aliases discovered during plugin expansion testing.

[D2RReimaginedTools.FileExtensions.0.4.0.nupkg.zip](https://github.com/user-attachments/files/26844078/D2RReimaginedTools.FileExtensions.0.4.0.nupkg.zip)
